### PR TITLE
2026-3-10 release readiness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "handoff"
-version = "2026.3.9"
+version = "2026.3.10"
 description = "Handoff — see who's on the hook across all your projects."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/handoff/version.py
+++ b/src/handoff/version.py
@@ -6,4 +6,4 @@ both for packaging and for displaying the running app version in the UI.
 
 from __future__ import annotations
 
-__version__ = "2026.3.9"
+__version__ = "2026.3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ wheels = [
 
 [[package]]
 name = "handoff"
-version = "2026.3.9"
+version = "2026.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump release version to `2026.3.10` to align with release notes and prepare for release.

---
<p><a href="https://cursor.com/agents/bc-ac231b14-b4bc-4c40-9057-df037ebe6bb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac231b14-b4bc-4c40-9057-df037ebe6bb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->