### PR TITLE
Distinct check-in labels: Current progress, Why delayed?, Conclusion

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,7 @@ Apply tags in this order. Use the first tag that matches.
 
 - **Improvement**
   - **Now page action row cleanup:** Removed Snooze; Edit is now inline with On-track | Delayed | Conclude in a single row. No Actions popover.
+  - **Distinct check-in labels:** Check-in form shows "Current progress (optional)" for On-track, "Why delayed? (optional)" for Delayed, and "Conclusion (optional)" for Conclude, so users see the right prompt for each check-in type.
 
 ## 2026.3.10 [Recommended]
 

--- a/src/handoff/pages/now.py
+++ b/src/handoff/pages/now.py
@@ -353,7 +353,7 @@ def _render_check_in_flow(handoff: Handoff, *, key_prefix: str) -> None:
     with st.form(key=form_key):
         if selected_mode == "concluded":
             st.text_area(
-                "Conclusion note (optional)",
+                "Conclusion (optional)",
                 key=note_key,
             )
             st.form_submit_button(
@@ -367,7 +367,11 @@ def _render_check_in_flow(handoff: Handoff, *, key_prefix: str) -> None:
                 },
             )
         else:
-            note_label = "Note (optional)" if selected_mode == "on_track" else "Reason (optional)"
+            note_label = (
+                "Current progress (optional)"
+                if selected_mode == "on_track"
+                else "Why delayed? (optional)"
+            )
             st.text_area(note_label, key=note_key)
             default_next_check = (
                 handoff.next_check


### PR DESCRIPTION
- On-track form: 'Current progress (optional)'
- Delayed form: 'Why delayed? (optional)'
- Conclude form: 'Conclusion (optional)' (was Conclusion note)
- Updated RELEASE_NOTES.md for 2026.3.11