### PR TITLE
Pr 2.1 implementation

### DIFF
--- a/src/handoff/rulebook.py
+++ b/src/handoff/rulebook.py
@@ -115,6 +115,8 @@ def rule_condition_to_dict(condition: RuleCondition) -> dict[str, Any]:
 
 def rule_condition_from_dict(payload: dict[str, Any]) -> RuleCondition:
     """Deserialize a rule condition from dictionary form."""
+    if not isinstance(payload, dict):
+        raise ValueError(f"rule condition payload must be a dict, got {type(payload)!r}")
     raw_type = payload.get("condition_type")
     try:
         condition_type = RuleConditionType(str(raw_type))
@@ -173,9 +175,14 @@ class RuleDefinition:
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> RuleDefinition:
         """Deserialize from dictionary form."""
+        if not isinstance(payload, dict):
+            raise ValueError(f"rule definition payload must be a dict, got {type(payload)!r}")
         conditions_payload = payload.get("conditions")
         if not isinstance(conditions_payload, list):
             raise ValueError("conditions must be a list")
+        for i, item in enumerate(conditions_payload):
+            if not isinstance(item, dict):
+                raise ValueError(f"conditions[{i}] must be a dict, got {type(item)!r}")
         return cls(
             rule_id=str(payload["rule_id"]),
             name=str(payload["name"]),
@@ -251,8 +258,11 @@ class RuleMatchResult:
             raise ValueError("explanation must be non-empty")
         if self.is_fallback and self.matched_rule_id is not None:
             raise ValueError("fallback match results must not include matched_rule_id")
-        if not self.is_fallback and self.matched_rule_id is None:
-            raise ValueError("non-fallback match results require matched_rule_id")
+        if not self.is_fallback:
+            if self.matched_rule_id is None:
+                raise ValueError("non-fallback match results require matched_rule_id")
+            if not self.matched_rule_id.strip():
+                raise ValueError("matched_rule_id must be non-empty for non-fallback match results")
 
 
 def build_default_rulebook_settings(*, deadline_near_days: int = 1) -> RulebookSettings:

--- a/tests/test_rulebook.py
+++ b/tests/test_rulebook.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from contextlib import contextmanager
 from datetime import date, timedelta
 
+import pytest
+
 import handoff.data as data
 from handoff.models import CheckIn, CheckInType, Handoff, Project
 from handoff.rulebook import (
@@ -171,25 +173,17 @@ def test_rulebook_validation_and_roundtrip() -> None:
         priority=30,
         conditions=(NextCheckDueCondition(),),
     )
-    try:
+    with pytest.raises(ValueError, match="rule_ids must be unique"):
         RulebookSettings(
             version=1,
             rules=(settings.rules[0], duplicate_rule),
         )
-    except ValueError as exc:
-        assert "rule_ids must be unique" in str(exc)
-    else:
-        raise AssertionError("Expected duplicate rule ids to raise ValueError")
 
 
 def test_rule_condition_and_match_result_validation() -> None:
     """Condition and match-result contracts reject invalid payloads."""
-    try:
+    with pytest.raises(ValueError, match="days >= 0"):
         DeadlineWithinDaysCondition(days=-1)
-    except ValueError as exc:
-        assert "days >= 0" in str(exc)
-    else:
-        raise AssertionError("Expected negative days to raise ValueError")
 
     fallback_result = RuleMatchResult(
         section_id=BuiltInSection.UPCOMING.value,
@@ -199,17 +193,21 @@ def test_rule_condition_and_match_result_validation() -> None:
     )
     assert fallback_result.is_fallback is True
 
-    try:
+    with pytest.raises(ValueError, match="require matched_rule_id"):
         RuleMatchResult(
             section_id=BuiltInSection.RISK.value,
             explanation="Matched risk rule.",
             matched_rule_id=None,
             is_fallback=False,
         )
-    except ValueError as exc:
-        assert "require matched_rule_id" in str(exc)
-    else:
-        raise AssertionError("Expected non-fallback result without rule id to raise ValueError")
+
+    with pytest.raises(ValueError, match="matched_rule_id must be non-empty"):
+        RuleMatchResult(
+            section_id=BuiltInSection.RISK.value,
+            explanation="Matched risk rule.",
+            matched_rule_id="   ",
+            is_fallback=False,
+        )
 
 
 def test_default_rules_mirror_current_section_semantics(session, monkeypatch) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add typed rulebook contracts, default definitions, and parity tests to implement PR 2.1 of the release plan.

<div><a href="https://cursor.com/agents/bc-10005680-a7ef-49f9-9b6c-9422035bf018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10005680-a7ef-49f9-9b6c-9422035bf018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->