### PR TITLE
Release 3.11 PR 3.1

### DIFF
--- a/src/handoff/data/__init__.py
+++ b/src/handoff/data/__init__.py
@@ -50,6 +50,7 @@ from handoff.data.queries import (
     query_concluded_handoffs,
     query_handoffs,
     query_now_items,
+    query_open_handoffs_for_now,
     query_risk_handoffs,
     query_upcoming_handoffs,
 )
@@ -101,6 +102,7 @@ __all__ = [
     "query_action_handoffs",
     "query_risk_handoffs",
     "query_concluded_handoffs",
+    "query_open_handoffs_for_now",
     "list_pitchmen",
     "list_pitchmen_with_open_handoffs",
     "get_projects_with_handoff_summary",

--- a/src/handoff/data/queries.py
+++ b/src/handoff/data/queries.py
@@ -371,6 +371,47 @@ def query_now_items(
     return result
 
 
+def query_open_handoffs_for_now(
+    *,
+    project_ids: list[int] | None = None,
+    pitchman_names: list[str] | None = None,
+    search_text: str | None = None,
+    next_check_min: date | None = None,
+    next_check_max: date | None = None,
+    deadline_min: date | None = None,
+    deadline_max: date | None = None,
+    include_archived_projects: bool = False,
+) -> list[Handoff]:
+    """Return all open handoffs matching Now-page filters for rulebook evaluation.
+
+    Used by the rulebook-backed Now snapshot. Returns handoffs without section
+    classification; the service layer evaluates each against the rulebook.
+    """
+    with session_context() as session:
+        stmt = select(Handoff).options(
+            selectinload(Handoff.project), selectinload(Handoff.check_ins)
+        )
+        stmt = stmt.where(_latest_check_in_is_open_predicate())
+        if not include_archived_projects:
+            stmt = stmt.where(Handoff.project.has(Project.is_archived.is_(False)))
+        stmt = _apply_handoff_filters(
+            stmt,
+            project_ids=project_ids,
+            pitchman_names=pitchman_names,
+            search_text=search_text,
+            next_check_min=next_check_min,
+            next_check_max=next_check_max,
+            deadline_min=deadline_min,
+            deadline_max=deadline_max,
+        )
+        stmt = stmt.order_by(
+            Handoff.next_check.asc().nulls_last(),
+            Handoff.deadline.asc().nulls_last(),
+            Handoff.created_at.asc(),
+        )
+        return list(session.exec(stmt).unique().all())
+
+
 def query_upcoming_handoffs(
     *,
     project_ids: list[int] | None = None,

--- a/src/handoff/services/handoff_service.py
+++ b/src/handoff/services/handoff_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 
 from handoff.data import conclude_handoff as _conclude_handoff
 from handoff.data import create_check_in as _create_check_in
@@ -15,15 +15,43 @@ from handoff.data import query_action_handoffs as _query_action_handoffs
 from handoff.data import query_concluded_handoffs as _query_concluded_handoffs
 from handoff.data import query_handoffs as _query_handoffs
 from handoff.data import query_now_items as _query_now_items
+from handoff.data import query_open_handoffs_for_now as _query_open_handoffs_for_now
 from handoff.data import query_risk_handoffs as _query_risk_handoffs
 from handoff.data import query_upcoming_handoffs as _query_upcoming_handoffs
 from handoff.data import reopen_handoff as _reopen_handoff
 from handoff.data import update_handoff as _update_handoff
 from handoff.models import CheckIn, CheckInType, Handoff, Project
 from handoff.page_models import HandoffQuery, NowSnapshot
+from handoff.rulebook import BuiltInSection, evaluate_open_handoff
 from handoff.search_parse import parse_search_query
 from handoff.services.project_service import list_projects
-from handoff.services.settings_service import get_deadline_near_days
+from handoff.services.settings_service import get_rulebook_settings
+
+UPCOMING_SECTION_LIMIT = 20
+
+
+def _sort_risk_handoffs(handoffs: list[Handoff]) -> list[Handoff]:
+    """Sort risk section by deadline, then next_check, then created_at."""
+    return sorted(
+        handoffs,
+        key=lambda h: (
+            h.deadline or date.max,
+            h.next_check or date.max,
+            h.created_at or datetime.max,
+        ),
+    )
+
+
+def _sort_action_or_upcoming_handoffs(handoffs: list[Handoff]) -> list[Handoff]:
+    """Sort action/upcoming by next_check, then deadline, then created_at."""
+    return sorted(
+        handoffs,
+        key=lambda h: (
+            h.next_check or date.max,
+            h.deadline or date.max,
+            h.created_at or datetime.max,
+        ),
+    )
 
 
 def get_now_snapshot(
@@ -38,35 +66,51 @@ def get_now_snapshot(
     """Return the full Now-page payload for rendering.
 
     Orchestrates section queries (Risk, Action required, Upcoming, Concluded)
-    with shared filters. Section semantics and order match the current
-    default behavior.
-
-    Callers may pass pre-fetched projects and pitchmen to avoid redundant
-    queries when the page has already loaded them for filters/add form.
+    with shared filters. Open handoffs are grouped via the rulebook engine;
+    Concluded remains lifecycle-driven.
     """
-    deadline_near_days = get_deadline_near_days()
     parsed = parse_search_query(search_text or "")
     open_common = {
         "project_ids": project_ids,
         "pitchman_names": pitchman_names,
         "search_text": parsed.text_query,
-        "deadline_near_days": deadline_near_days,
         "next_check_min": parsed.next_check_min,
         "next_check_max": parsed.next_check_max,
         "deadline_min": parsed.deadline_min,
         "deadline_max": parsed.deadline_max,
         "include_archived_projects": include_archived_projects,
     }
+    open_handoffs = _query_open_handoffs_for_now(**open_common)
+
+    rulebook = get_rulebook_settings()
+    today = date.today()
+
+    risk: list[Handoff] = []
+    action: list[Handoff] = []
+    upcoming: list[Handoff] = []
+
+    for handoff in open_handoffs:
+        match_result = evaluate_open_handoff(handoff, settings=rulebook, today=today)
+        if match_result.section_id == BuiltInSection.RISK.value:
+            risk.append(handoff)
+        elif match_result.section_id == BuiltInSection.ACTION_REQUIRED.value:
+            action.append(handoff)
+        elif match_result.section_id == BuiltInSection.UPCOMING.value:
+            upcoming.append(handoff)
+        # Custom section ids from user config are dropped for now; v1 only renders built-ins.
+
+    risk = _sort_risk_handoffs(risk)
+    action = _sort_action_or_upcoming_handoffs(action)
+    upcoming = _sort_action_or_upcoming_handoffs(upcoming)[:UPCOMING_SECTION_LIMIT]
+
     concluded_common = {
         "project_ids": project_ids,
         "pitchman_names": pitchman_names,
         "search_text": parsed.text_query,
         "include_archived_projects": include_archived_projects,
     }
-    risk = query_risk_handoffs(**open_common)
-    action = query_action_handoffs(**open_common)
-    upcoming = query_upcoming_handoffs(**open_common)
-    concluded = query_concluded_handoffs(**concluded_common)
+    concluded = _query_concluded_handoffs(**concluded_common)
+
     if projects is None:
         projects = list_projects(include_archived=include_archived_projects)
     if pitchmen is None:

--- a/tests/test_todo_service.py
+++ b/tests/test_todo_service.py
@@ -458,9 +458,11 @@ def test_service_get_now_snapshot_contract(session, monkeypatch) -> None:
             return date(2026, 3, 9)
 
     _patch_date(monkeypatch, FixedDate)
+    from handoff.rulebook import build_default_rulebook_settings
+
     monkeypatch.setattr(
-        "handoff.services.handoff_service.get_deadline_near_days",
-        lambda: 1,
+        "handoff.services.handoff_service.get_rulebook_settings",
+        lambda: build_default_rulebook_settings(deadline_near_days=1),
     )
 
     p = Project(name="Work")
@@ -492,19 +494,18 @@ def test_service_get_now_snapshot_contract(session, monkeypatch) -> None:
 
 def test_service_get_now_snapshot_uses_prefetched_supporting_data(monkeypatch) -> None:
     """Prefetched projects/pitchmen are returned directly without extra list queries."""
+    from handoff.rulebook import build_default_rulebook_settings
+
     monkeypatch.setattr(
-        "handoff.services.handoff_service.get_deadline_near_days",
-        lambda: 1,
-    )
-    monkeypatch.setattr("handoff.services.handoff_service.query_risk_handoffs", lambda **kwargs: [])
-    monkeypatch.setattr(
-        "handoff.services.handoff_service.query_action_handoffs", lambda **kwargs: []
+        "handoff.services.handoff_service.get_rulebook_settings",
+        lambda: build_default_rulebook_settings(deadline_near_days=1),
     )
     monkeypatch.setattr(
-        "handoff.services.handoff_service.query_upcoming_handoffs", lambda **kwargs: []
+        "handoff.services.handoff_service._query_open_handoffs_for_now",
+        lambda **kwargs: [],
     )
     monkeypatch.setattr(
-        "handoff.services.handoff_service.query_concluded_handoffs",
+        "handoff.services.handoff_service._query_concluded_handoffs",
         lambda **kwargs: [],
     )
     monkeypatch.setattr(
@@ -540,9 +541,11 @@ def test_service_get_now_snapshot_default_section_counts(session, monkeypatch) -
             return date(2026, 3, 9)
 
     _patch_date(monkeypatch, FixedDate)
+    from handoff.rulebook import build_default_rulebook_settings
+
     monkeypatch.setattr(
-        "handoff.services.handoff_service.get_deadline_near_days",
-        lambda: 1,
+        "handoff.services.handoff_service.get_rulebook_settings",
+        lambda: build_default_rulebook_settings(deadline_near_days=1),
     )
 
     p = Project(name="Work")
@@ -597,8 +600,77 @@ def test_service_get_now_snapshot_default_section_counts(session, monkeypatch) -
     assert snapshot.projects[0].name == "Work"
 
 
+def test_service_get_now_snapshot_rulebook_parity_with_legacy_queries(session, monkeypatch) -> None:
+    """Default rulebook produces same open-section membership as legacy query logic."""
+    _patch_session_context(monkeypatch, session)
+
+    class FixedDate(date):
+        @classmethod
+        def today(cls) -> date:
+            return date(2026, 3, 9)
+
+    _patch_date(monkeypatch, FixedDate)
+    from handoff.rulebook import build_default_rulebook_settings
+
+    monkeypatch.setattr(
+        "handoff.services.handoff_service.get_rulebook_settings",
+        lambda: build_default_rulebook_settings(deadline_near_days=1),
+    )
+
+    p = Project(name="Work")
+    session.add(p)
+    session.commit()
+    session.refresh(p)
+
+    data.create_handoff(
+        project_id=p.id,
+        need_back="Due now",
+        next_check=date(2026, 3, 9),
+    )
+    data.create_handoff(
+        project_id=p.id,
+        need_back="Later",
+        next_check=date(2026, 4, 1),
+    )
+    risk_h = data.create_handoff(
+        project_id=p.id,
+        need_back="At risk",
+        next_check=date(2026, 3, 9),
+        deadline=date(2026, 3, 10),
+    )
+    data.create_check_in(
+        handoff_id=risk_h.id,
+        check_in_type=CheckInType.DELAYED,
+        check_in_date=date(2026, 3, 9),
+    )
+    concluded_h = data.create_handoff(
+        project_id=p.id,
+        need_back="Closed",
+        next_check=date(2026, 3, 9),
+    )
+    data.create_check_in(
+        handoff_id=concluded_h.id,
+        check_in_type=CheckInType.CONCLUDED,
+        check_in_date=date(2026, 3, 9),
+    )
+
+    snapshot = get_now_snapshot()
+
+    legacy_risk = {h.id for h in query_risk_handoffs(deadline_near_days=1)}
+    legacy_action = {h.id for h in query_action_handoffs(deadline_near_days=1)}
+    legacy_upcoming = {h.id for h in query_upcoming_handoffs(deadline_near_days=1)}
+
+    snapshot_risk_ids = {h.id for h in snapshot.risk}
+    snapshot_action_ids = {h.id for h in snapshot.action}
+    snapshot_upcoming_ids = {h.id for h in snapshot.upcoming}
+
+    assert snapshot_risk_ids == legacy_risk
+    assert snapshot_action_ids == legacy_action
+    assert snapshot_upcoming_ids == legacy_upcoming
+
+
 def test_service_get_now_snapshot_forwards_parsed_filters(monkeypatch) -> None:
-    """Snapshot query fan-out uses parsed search/date filters for risk/action/upcoming sections."""
+    """Snapshot query fan-out uses parsed search/date filters for open and concluded sections."""
     parsed = SimpleNamespace(
         text_query="release gate",
         next_check_min=date(2026, 3, 1),
@@ -607,26 +679,15 @@ def test_service_get_now_snapshot_forwards_parsed_filters(monkeypatch) -> None:
         deadline_max=date(2026, 4, 5),
     )
     monkeypatch.setattr("handoff.services.handoff_service.parse_search_query", lambda _: parsed)
-    monkeypatch.setattr("handoff.services.handoff_service.get_deadline_near_days", lambda: 3)
 
-    risk_calls: list[dict[str, object]] = []
-    action_calls: list[dict[str, object]] = []
-    upcoming_calls: list[dict[str, object]] = []
+    open_calls: list[dict[str, object]] = []
     concluded_calls: list[dict[str, object]] = []
     monkeypatch.setattr(
-        "handoff.services.handoff_service.query_risk_handoffs",
-        lambda **kwargs: risk_calls.append(kwargs) or [],
+        "handoff.services.handoff_service._query_open_handoffs_for_now",
+        lambda **kwargs: open_calls.append(kwargs) or [],
     )
     monkeypatch.setattr(
-        "handoff.services.handoff_service.query_action_handoffs",
-        lambda **kwargs: action_calls.append(kwargs) or [],
-    )
-    monkeypatch.setattr(
-        "handoff.services.handoff_service.query_upcoming_handoffs",
-        lambda **kwargs: upcoming_calls.append(kwargs) or [],
-    )
-    monkeypatch.setattr(
-        "handoff.services.handoff_service.query_concluded_handoffs",
+        "handoff.services.handoff_service._query_concluded_handoffs",
         lambda **kwargs: concluded_calls.append(kwargs) or [],
     )
 
@@ -652,7 +713,6 @@ def test_service_get_now_snapshot_forwards_parsed_filters(monkeypatch) -> None:
         "project_ids": [7],
         "pitchman_names": ["Alice"],
         "search_text": "release gate",
-        "deadline_near_days": 3,
         "next_check_min": date(2026, 3, 1),
         "next_check_max": date(2026, 3, 31),
         "deadline_min": date(2026, 3, 5),
@@ -665,9 +725,7 @@ def test_service_get_now_snapshot_forwards_parsed_filters(monkeypatch) -> None:
         "search_text": "release gate",
         "include_archived_projects": True,
     }
-    assert risk_calls == [open_expected]
-    assert action_calls == [open_expected]
-    assert upcoming_calls == [open_expected]
+    assert open_calls == [open_expected]
     assert concluded_calls == [concluded_expected]
     assert list_projects_calls == [{"include_archived": True}]
     assert list_pitchmen_calls == [{"include_archived_projects": True}]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refactor Now-page sectioning to use a rulebook-backed matching engine.

This change replaces hard-coded queries for Risk, Action required, and Upcoming sections with a flexible rulebook evaluation, while maintaining default behavior parity with the legacy system.

<div><a href="https://cursor.com/agents/bc-01ba6847-3948-4f5c-b9c0-a8acdf17901a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01ba6847-3948-4f5c-b9c0-a8acdf17901a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->