### PR TITLE
Plan item PR5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ To keep the app simple and robust, some things are intentionally out of scope:
    - **Action required**: next check due/overdue
    - **Upcoming**: open and not in Risk/Action
    - **Concluded**: latest check-in is concluded
-   You can add/edit handoffs, check in early or when due, conclude, and reopen
-   from Concluded (append-only history). Filters: Project, Who, Search, and
-   "Include archived projects".
+   Section rules are configurable via **System Settings** → **Open-item rules**.
+   You can edit built-in rules, add custom sections, or **Reset to defaults** to
+   restore the original behavior. You can add/edit handoffs, check in early or
+   when due, conclude, and reopen from Concluded (append-only history). Filters:
+   Project, Who, Search, and "Include archived projects".
 4. **Dashboard** - PM-operational metrics focused on execution reliability:
    at-risk now, action overdue, open aging profile, on-time close trend, cycle
    time by project (p50/p90), and reopen rate.
@@ -90,9 +92,11 @@ To keep the app simple and robust, some things are intentionally out of scope:
 
 By default, the SQLite database is stored in your per-user data directory so app
 updates do not overwrite your data (for example on Windows:
-`%APPDATA%\handoff\todo.db`, retained for backward compatibility). You can
-override the location by setting the `HANDOFF_DB_PATH` environment variable
-before starting the app.
+`%APPDATA%\handoff\todo.db`, retained for backward compatibility). The rulebook
+and other local settings (e.g. deadline-at-risk days) live in
+`handoff_settings.json` next to the database. You can override the database
+location by setting the `HANDOFF_DB_PATH` environment variable before starting
+the app.
 
 > **Migrating from `TODO_APP_DB_PATH`:** The legacy `TODO_APP_DB_PATH`
 > environment variable is no longer recognised. If you were using it to point

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,7 +28,12 @@ Apply tags in this order. Use the first tag that matches.
 ## 2026.3.11 [Breaking]
 
 - **Feature**
+  - **Configurable rulebook for Now-page sections:** Open-item sections (Risk, Action required, Upcoming) are now driven by an editable rulebook. Rules are exclusive and first-match-wins by priority. Built-in defaults reproduce the previous behavior at launch.
+  - **Rulebook editor in System Settings:** Under **Open-item rules**, you can edit enabled state, priority, and conditions per rule; add custom sections beyond Risk and Action required; and reset to built-in defaults at any time.
+  - **"Why this matched" explanations:** Each handoff in a rulebook-driven section shows a short explanation of why it landed there (e.g. "Deadline is near and latest check-in is delayed.").
   - **Now page keyboard shortcut:** Press `a` to expand the Add handoff form. Shortcuts caption shown on the page.
+- **Improvement**
+  - **Returning to defaults:** If you customize rules and want the original behavior back, go to **Settings** → **System Settings** → **Open-item rules** and click **Reset to defaults**. The Now page picks up changes on the next refresh.
 - **Breaking**
   - **Streamlit 1.52+ required:** Minimum Streamlit version bumped from 1.40 to 1.52 for `st.button(shortcut=...)` support. Full reinstall needed for embedded builds. Users who patch-update in-place get a try/except fallback: the button works without the shortcut if their bundled Streamlit is older.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Document the new configurable rulebook features for Now-page sections and their storage location.

This PR updates `RELEASE_NOTES.md` and `README.md` to reflect the introduction of editable rulebooks for open-item sections, a rulebook editor in System Settings, "Why this matched" explanations, and the storage location of the rulebook, fulfilling PR5.2 of the release plan.

<div><a href="https://cursor.com/agents/bc-4ade44b4-15a4-41fd-98ce-50aa7fbca747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ade44b4-15a4-41fd-98ce-50aa7fbca747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->