### PR TITLE
Fix: handoffs no longer auto-expand; operations on one don't affect o…

### DIFF
--- a/src/handoff/pages/now.py
+++ b/src/handoff/pages/now.py
@@ -505,9 +505,10 @@ def _render_item(
     keep_expanded_for_mode = (
         allow_actions and show_check_in_controls and has_active_check_in_mode
     ) or (allow_reopen and has_active_reopen_mode)
-    # Auto-expand for due action items so check-in controls are visible without clicking
-    is_due_action = show_check_in_controls and _is_check_in_due(handoff)
-    with st.expander(header, expanded=editing or keep_expanded_for_mode or is_due_action):
+    # Default collapsed; only expand when editing or form mode is active.
+    # Removed is_due_action so operations on one handoff don't expand others.
+    expanded = editing or keep_expanded_for_mode
+    with st.expander(header, expanded=expanded):
         if match_explanation:
             st.caption(match_explanation)
         if not editing and allow_actions and show_check_in_controls:

--- a/tests/test_pages_now.py
+++ b/tests/test_pages_now.py
@@ -1791,10 +1791,10 @@ def test_render_now_page_no_projects_with_include_archived_true_shows_create_inf
 # --- Regression tests for PR #88: Snooze removal + segmented_control ---
 
 
-def test_render_item_auto_expands_due_action_items(
+def test_render_item_does_not_auto_expand_due_action_items(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Due action items auto-expand so check-in controls are visible without clicking."""
+    """Due action items start collapsed; user must expand to see check-in controls."""
     st_mock = _build_streamlit_mock()
     monkeypatch.setattr("handoff.pages.now.st", st_mock)
 
@@ -1805,7 +1805,6 @@ def test_render_item_auto_expands_due_action_items(
 
     monkeypatch.setattr("handoff.pages.now.date", FixedDate)
 
-    # Handoff due today should auto-expand
     due_handoff = _make_fake_handoff(
         handoff_id=100,
         need_back="Due now",
@@ -1821,8 +1820,8 @@ def test_render_item_auto_expands_due_action_items(
         allow_actions=True,
     )
 
-    # Expander should be expanded due to is_due_action logic
-    assert st_mock.expander.call_args.kwargs["expanded"] is True
+    # Expander starts collapsed; user expands manually
+    assert st_mock.expander.call_args.kwargs["expanded"] is False
 
 
 def test_render_item_does_not_auto_expand_future_items(
@@ -1832,7 +1831,6 @@ def test_render_item_does_not_auto_expand_future_items(
     st_mock = _build_streamlit_mock()
     monkeypatch.setattr("handoff.pages.now.st", st_mock)
 
-    # Handoff due in the future should not auto-expand
     future_handoff = _make_fake_handoff(
         handoff_id=101,
         need_back="Future check",
@@ -1848,7 +1846,7 @@ def test_render_item_does_not_auto_expand_future_items(
         allow_actions=True,
     )
 
-    # Expander should not be expanded (no active mode, not due)
+    # Expander starts collapsed (no active mode, not due)
     assert st_mock.expander.call_args.kwargs["expanded"] is False
 
 


### PR DESCRIPTION
…thers

- Remove is_due_action from expand logic so due items start collapsed
- Only expand when editing or form mode (check-in/reopen) is active
- Update tests: due items start collapsed, future items unchanged