### PR TITLE
Project structure restructure PR6

### DIFF
--- a/src/handoff/data/__init__.py
+++ b/src/handoff/data/__init__.py
@@ -6,11 +6,7 @@ This package re-exports the public API from focused sub-modules so that existing
 
 from handoff.data.activity import get_recent_activity, log_activity
 from handoff.data.handoffs import (
-    _UNSET,
     CheckInType,
-    _latest_check_in,
-    _pitchman_to_db,
-    _Unset,
     conclude_handoff,
     create_check_in,
     create_handoff,
@@ -32,16 +28,6 @@ from handoff.data.projects import (
     unarchive_project,
 )
 from handoff.data.queries import (
-    _apply_handoff_filters,
-    _check_in_note_subquery,
-    _is_risk_handoff,
-    _last_check_in_is_delayed,
-    _last_concluded_check_in_date_subquery,
-    _latest_check_in_is_concluded_predicate,
-    _latest_check_in_is_open_predicate,
-    _latest_check_in_type_subquery,
-    _to_end_of_day,
-    _to_start_of_day,
     count_open_handoffs,
     get_projects_with_handoff_summary,
     list_pitchmen,
@@ -56,31 +42,12 @@ from handoff.data.queries import (
 )
 
 __all__ = [
-    "_UNSET",
-    # models re-exported for convenience
     "CheckInType",
-    # handoffs
-    "_Unset",
-    "_apply_handoff_filters",
-    "_check_in_note_subquery",
-    "_is_risk_handoff",
-    # queries
-    "_last_check_in_is_delayed",
-    "_last_concluded_check_in_date_subquery",
-    "_latest_check_in",
-    "_latest_check_in_is_concluded_predicate",
-    "_latest_check_in_is_open_predicate",
-    "_latest_check_in_type_subquery",
-    "_pitchman_to_db",
-    "_to_end_of_day",
-    "_to_start_of_day",
     "archive_project",
     "conclude_handoff",
     "count_open_handoffs",
-    # check-ins
     "create_check_in",
     "create_handoff",
-    # projects
     "create_project",
     "delete_handoff",
     "delete_project",
@@ -91,12 +58,10 @@ __all__ = [
     "get_recent_activity",
     "handoff_is_closed",
     "handoff_is_open",
-    # import/export
     "import_payload",
     "list_pitchmen",
     "list_pitchmen_with_open_handoffs",
     "list_projects",
-    # activity
     "log_activity",
     "query_action_handoffs",
     "query_concluded_handoffs",

--- a/src/handoff/data/handoffs.py
+++ b/src/handoff/data/handoffs.py
@@ -259,11 +259,6 @@ def conclude_handoff(handoff_id: int, note: str | None = None) -> CheckIn:
     return check_in
 
 
-def _latest_check_in(handoff: Handoff) -> CheckIn | None:
-    """Return the latest check-in on a handoff trail, or None."""
-    return handoff_lifecycle._latest_check_in(handoff)
-
-
 def handoff_is_open(handoff: Handoff) -> bool:
     """Return True when the latest check-in is not concluded."""
     return handoff_lifecycle.handoff_is_open(handoff)

--- a/src/handoff/data/queries.py
+++ b/src/handoff/data/queries.py
@@ -10,9 +10,9 @@ from sqlalchemy import exists, func
 from sqlalchemy.orm import selectinload
 from sqlmodel import or_, select
 
+from handoff.core.handoff_lifecycle import _latest_check_in, handoff_is_open
 from handoff.core.models import CheckIn, CheckInType, Handoff, Project
 from handoff.core.page_models import HandoffQuery
-from handoff.data.handoffs import _latest_check_in, handoff_is_open
 from handoff.db import session_context
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement PR6 by cleaning up the data layer to centralize `handoff_lifecycle` functions in `handoff.core` and expose only public APIs from `handoff.data`.

<div><a href="https://cursor.com/agents/bc-f0061bf9-307f-436d-811e-2f7eaf3959e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0061bf9-307f-436d-811e-2f7eaf3959e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->