### PR TITLE
Address Copilot review feedback (launcher xcopy, updater messages, tests)

### DIFF
--- a/scripts/build_full.py
+++ b/scripts/build_full.py
@@ -328,11 +328,12 @@ def _write_handoff_bat() -> None:
         if exist "%SCRIPT_DIR%update\*" (
             echo Applying update...
             xcopy /E /Y "%SCRIPT_DIR%update\*" "%SCRIPT_DIR%" >nul
-            if errorlevel 1 (
+            set XCOPY_EXIT=%ERRORLEVEL%
+            if %XCOPY_EXIT% GEQ 2 (
                 echo Update failed. Staged files are still in .\update\ for retry.
                 echo Close running apps and run handoff.bat again.
                 endlocal
-                exit /b 1
+                exit /b %XCOPY_EXIT%
             )
             rmdir /s /q "%SCRIPT_DIR%update" 2>nul
             echo Update applied.

--- a/src/handoff/updater.py
+++ b/src/handoff/updater.py
@@ -134,7 +134,7 @@ def _copy_tree_files(src_root: Path, dest_root: Path) -> tuple[list[str], list[s
             shutil.copy2(src, dest)
             copied.append(rel_name)
         except (PermissionError, OSError) as e:
-            logger.warning("Could not copy {} to {}: {}", src, dest, e)
+            logger.warning("Could not copy {} to {}: {}", rel_name, dest, e)
             failed.append(rel_name)
     return copied, failed
 
@@ -245,9 +245,11 @@ def stage_patch_with_backup(
             tmp_staging = Path(tmpdir)
             extracted, extract_failed = _extract_zip_to_dir(zf, members, tmp_staging)
             if not extracted:
-                return f"Failed to extract patch to ./{UPDATE_STAGING_DIR}."
+                return "Failed to extract patch from zip."
             if extract_failed:
-                logger.warning("Some files could not be staged: {}", extract_failed)
+                logger.warning(
+                    "Some files could not be extracted from the patch: {}", extract_failed
+                )
 
             try:
                 staging = _reset_update_staging_dir(app_root)
@@ -256,13 +258,13 @@ def stage_patch_with_backup(
             copied, copy_failed = _copy_tree_files(tmp_staging, staging)
             if not copied:
                 shutil.rmtree(staging, ignore_errors=True)
-                return f"Failed to stage patch to ./{UPDATE_STAGING_DIR}."
+                return f"Failed to copy patch into ./{UPDATE_STAGING_DIR}."
             if copy_failed:
                 logger.warning(
                     "Staging copy failed for {} file(s): {}", len(copy_failed), copy_failed
                 )
                 shutil.rmtree(staging, ignore_errors=True)
-                return f"Failed to stage patch to ./{UPDATE_STAGING_DIR}."
+                return f"Failed to copy patch into ./{UPDATE_STAGING_DIR}."
 
     logger.info("Patch unzipped to {} containing: {}", staging, extracted)
 
@@ -299,7 +301,11 @@ def stage_patch_with_backup(
         msg = "Update files are ready. Close in 2s. Run handoff.bat again to complete the update."
 
     if extract_failed:
-        msg += f" Warning: {len(extract_failed)} file(s) could not be staged."
+        msg += f" Warning: {len(extract_failed)} file(s) could not be extracted from the patch."
+    if copy_failed:
+        msg += (
+            f" Warning: {len(copy_failed)} file(s) could not be copied into ./{UPDATE_STAGING_DIR}."
+        )
     return msg
 
 
@@ -333,9 +339,11 @@ def extract_patch_to_staging(file_like: BinaryIO, app_root: Path | None = None) 
             tmp_staging = Path(tmpdir)
             extracted, extract_failed = _extract_zip_to_dir(zf, members, tmp_staging)
             if not extracted:
-                return f"Failed to extract patch to ./{UPDATE_STAGING_DIR}."
+                return "Failed to extract patch from zip."
             if extract_failed:
-                logger.warning("Some files could not be staged: {}", extract_failed)
+                logger.warning(
+                    "Some files could not be extracted from the patch: {}", extract_failed
+                )
 
             try:
                 staging = _reset_update_staging_dir(app_root)
@@ -344,13 +352,13 @@ def extract_patch_to_staging(file_like: BinaryIO, app_root: Path | None = None) 
             copied, copy_failed = _copy_tree_files(tmp_staging, staging)
             if not copied:
                 shutil.rmtree(staging, ignore_errors=True)
-                return f"Failed to stage patch to ./{UPDATE_STAGING_DIR}."
+                return f"Failed to copy patch into ./{UPDATE_STAGING_DIR}."
             if copy_failed:
                 logger.warning(
                     "Staging copy failed for {} file(s): {}", len(copy_failed), copy_failed
                 )
                 shutil.rmtree(staging, ignore_errors=True)
-                return f"Failed to stage patch to ./{UPDATE_STAGING_DIR}."
+                return f"Failed to copy patch into ./{UPDATE_STAGING_DIR}."
 
     if target_version:
         logger.info("Staged patch for version {} in {}", target_version, staging)
@@ -367,7 +375,7 @@ def extract_patch_to_staging(file_like: BinaryIO, app_root: Path | None = None) 
         )
 
     if extract_failed:
-        msg += f" Warning: {len(extract_failed)} file(s) could not be staged."
+        msg += f" Warning: {len(extract_failed)} file(s) could not be extracted from the patch."
     return msg
 
 

--- a/tests/test_build_artifacts.py
+++ b/tests/test_build_artifacts.py
@@ -245,8 +245,21 @@ def test_write_handoff_bat_keeps_staging_on_xcopy_failure(
     build_full_module._write_handoff_bat()
     content = (app_build_dir / "handoff.bat").read_text(encoding="utf-8")
 
-    assert 'xcopy /E /Y "%SCRIPT_DIR%update\\*" "%SCRIPT_DIR%" >nul' in content
-    assert "if errorlevel 1 (" in content
+    xcopy_line = 'xcopy /E /Y "%SCRIPT_DIR%update\\*" "%SCRIPT_DIR%" >nul'
+    guard_line = "if %XCOPY_EXIT% GEQ 2 ("
+    exit_line = "exit /b %XCOPY_EXIT%"
+    remove_update_line = 'rmdir /s /q "%SCRIPT_DIR%update" 2>nul'
+
+    assert xcopy_line in content
+    assert "set XCOPY_EXIT=%ERRORLEVEL%" in content
+    assert guard_line in content
     assert "Update failed. Staged files are still in .\\update\\ for retry." in content
     assert "Close running apps and run handoff.bat again." in content
-    assert "exit /b 1" in content
+    assert exit_line in content
+
+    xcopy_index = content.find(xcopy_line)
+    guard_index = content.find(guard_line)
+    exit_index = content.find(exit_line)
+    remove_index = content.find(remove_update_line)
+    assert xcopy_index != -1 and guard_index != -1 and exit_index != -1 and remove_index != -1
+    assert xcopy_index < guard_index < exit_index < remove_index

--- a/tests/test_build_dry_run.py
+++ b/tests/test_build_dry_run.py
@@ -34,7 +34,19 @@ def test_build_full_dry_run_creates_build_structure(
     assert (app_dir / "RELEASE_NOTES.md").exists()
     assert (app_dir / "src" / "handoff").exists()
     # Windows dry-run writes handoff.bat
-    assert (app_dir / "handoff.bat").exists()
+    bat_path = app_dir / "handoff.bat"
+    assert bat_path.exists()
+    launcher_content = bat_path.read_text(encoding="utf-8")
+    xcopy_line = 'xcopy /E /Y "%SCRIPT_DIR%update\\*" "%SCRIPT_DIR%" >nul'
+    guard_line = "if %XCOPY_EXIT% GEQ 2 ("
+    exit_line = "exit /b %XCOPY_EXIT%"
+    remove_update_line = 'rmdir /s /q "%SCRIPT_DIR%update" 2>nul'
+    xcopy_index = launcher_content.find(xcopy_line)
+    guard_index = launcher_content.find(guard_line)
+    exit_index = launcher_content.find(exit_line)
+    remove_index = launcher_content.find(remove_update_line)
+    assert xcopy_index != -1 and guard_index != -1 and exit_index != -1 and remove_index != -1
+    assert xcopy_index < guard_index < exit_index < remove_index
 
 
 def test_build_full_dry_run_mac_creates_sh_launcher(

--- a/tests/test_cli_interface.py
+++ b/tests/test_cli_interface.py
@@ -16,17 +16,17 @@ ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "pyproject.toml"
 
 
-def _runtime_dependency_names() -> set[str]:
-    """Return normalized package names from [project].dependencies."""
+def _runtime_dependency_specs() -> dict[str, str]:
+    """Map normalized package name to full requirement line from [project].dependencies."""
     with PYPROJECT.open("rb") as fp:
         data = tomllib.load(fp)
     deps = data["project"].get("dependencies", [])
-    names: set[str] = set()
+    specs: dict[str, str] = {}
     for spec in deps:
-        match = re.match(r"^[A-Za-z0-9_.-]+", spec)
+        match = re.match(r"^([A-Za-z0-9_.-]+)", spec)
         if match:
-            names.add(match.group(0).lower())
-    return names
+            specs[match.group(1).lower()] = spec.strip()
+    return specs
 
 
 def test_cli_module_exports_main_and_app() -> None:
@@ -53,6 +53,10 @@ def test_cli_command_stub_via_invoke() -> None:
 
 def test_app_cli_runtime_dependencies_include_typer_and_rich() -> None:
     """Runtime deps must include CLI modules imported by handoff entrypoint."""
-    runtime_deps = _runtime_dependency_names()
-    assert "typer" in runtime_deps
-    assert "rich" in runtime_deps
+    specs = _runtime_dependency_specs()
+    typer_spec = specs.get("typer")
+    rich_spec = specs.get("rich")
+    assert typer_spec is not None, "typer must be a runtime dependency"
+    assert rich_spec is not None, "rich must be a runtime dependency"
+    assert re.search(r">=\s*0\.12\.3", typer_spec), typer_spec
+    assert re.search(r">=\s*13\.7\.0", rich_spec), rich_spec

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -66,7 +66,6 @@ class TestLaunchers:
         assert xcopy_index != -1 and guard_index != -1 and exit_index != -1 and remove_index != -1
         assert xcopy_index < guard_index < exit_index < remove_index
         assert "Update failed. Staged files are still in .\\update\\ for retry." in content
-        assert "exit /b 1" in content
         assert "python\\python.exe" in content
         assert "PYTHONPATH" in content
         assert "PYTHONHOME" in content

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -49,8 +49,22 @@ class TestLaunchers:
         # Verify the batch file contains the expected logic strings
         # We check for the core parts of the update and execution logic
         assert 'if exist "%SCRIPT_DIR%update\\*"' in content
-        assert 'xcopy /E /Y "%SCRIPT_DIR%update\\*" "%SCRIPT_DIR%"' in content
-        assert "if errorlevel 1 (" in content
+        xcopy_line = 'xcopy /E /Y "%SCRIPT_DIR%update\\*" "%SCRIPT_DIR%"'
+        guard_line = "if %XCOPY_EXIT% GEQ 2 ("
+        exit_line = "exit /b %XCOPY_EXIT%"
+        remove_update_line = 'rmdir /s /q "%SCRIPT_DIR%update" 2>nul'
+
+        assert xcopy_line in content
+        assert "set XCOPY_EXIT=%ERRORLEVEL%" in content
+        assert guard_line in content
+        assert exit_line in content
+
+        xcopy_index = content.find(xcopy_line)
+        guard_index = content.find(guard_line)
+        exit_index = content.find(exit_line)
+        remove_index = content.find(remove_update_line)
+        assert xcopy_index != -1 and guard_index != -1 and exit_index != -1 and remove_index != -1
+        assert xcopy_index < guard_index < exit_index < remove_index
         assert "Update failed. Staged files are still in .\\update\\ for retry." in content
         assert "exit /b 1" in content
         assert "python\\python.exe" in content

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -277,7 +277,7 @@ def test_stage_patch_with_backup_cleans_staging_on_partial_copy_failure(
         app_version="2026.3.1",
     )
 
-    assert message == "Failed to stage patch to ./update."
+    assert message == "Failed to copy patch into ./update."
     assert not (app_root / "update").exists()
     assert not (app_root / "backup").exists()
     assert (app_root / "app.py").read_text(encoding="utf-8") == "old app"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to Copilot inline review comments on the updater / Windows launcher / CLI dependency tests.

**Changes**
- **handoff.bat**: Treat `xcopy` exit code `>= 2` as failure (per xcopy semantics); capture `%ERRORLEVEL%` and `exit /b` with the same code so exit code 1 is not misread as a hard failure.
- **updater**: Distinguish zip extraction failures from staging copy failures in user-facing strings; log staging copy warnings with POSIX relative paths.
- **Tests**: Assert ordering `xcopy` → failure guard → `exit` → `rmdir` in generated launcher and dry-run output; tighten CLI runtime dependency test to check package names and minimum versions without matching full requirement strings verbatim.

Local `uv run handoff-dev ci` passes.

Closes the loop on Copilot feedback from superseded draft PRs (#204–#218, #206–#213, #215–#216, #218, #209).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed897acf-5dd0-4d89-a882-0161ed65c9a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed897acf-5dd0-4d89-a882-0161ed65c9a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

